### PR TITLE
1.1.0 (3) fix image migration failures

### DIFF
--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -1,6 +1,6 @@
 import 'package:medication_tracker/data/model/medication_model.dart';
 import 'package:medication_tracker/data/model/user_profile_model.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 
@@ -100,10 +100,6 @@ class DatabaseService {
             List<Map<String, dynamic>> oldMedicationsRead =
                 await oldMedsDb.query('medication_table');
 
-            // Get application documents directory
-            final appDocDir = await getApplicationDocumentsDirectory();
-            String path = appDocDir.path;
-
             for (var medicationRead in oldMedicationsRead) {
               // Create modifiable copy
               Map<String, dynamic> medication =
@@ -111,11 +107,8 @@ class DatabaseService {
               medication['profile_id'] = defaultProfileId;
 
               // Ensure only the file name is saved in imageUrl
-              if ((medication['imageUrl'] as String).contains(path)) {
-                medication['imageUrl'] = (medication['imageUrl'] as String)
-                    .replaceAll(path, "")
-                    .trim();
-              }
+              medication['imageUrl'] =
+                  path.basename(medication['imageUrl'] as String);
 
               await txn.insert(medicationTable, medication);
             }

--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -1,5 +1,6 @@
 import 'package:medication_tracker/data/model/medication_model.dart';
 import 'package:medication_tracker/data/model/user_profile_model.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 
@@ -99,11 +100,23 @@ class DatabaseService {
             List<Map<String, dynamic>> oldMedicationsRead =
                 await oldMedsDb.query('medication_table');
 
+            // Get application documents directory
+            final appDocDir = await getApplicationDocumentsDirectory();
+            String path = appDocDir.path;
+
             for (var medicationRead in oldMedicationsRead) {
               // Create modifiable copy
               Map<String, dynamic> medication =
                   Map<String, dynamic>.from(medicationRead);
               medication['profile_id'] = defaultProfileId;
+
+              // Ensure only the file name is saved in imageUrl
+              if ((medication['imageUrl'] as String).contains(path)) {
+                medication['imageUrl'] = (medication['imageUrl'] as String)
+                    .replaceAll(path, "")
+                    .trim();
+              }
+
               await txn.insert(medicationTable, medication);
             }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+2
+version: 1.1.0+3
 
 environment:
   sdk: '>=3.1.5 <4.0.0'


### PR DESCRIPTION
# Force imageUrl to be base path (not full container path) when migrating

This pull request includes several changes to the `lib/data/database/database.dart` file and a version update in the `pubspec.yaml` file. The most important changes are focused on ensuring the correct handling of file paths and updating the project version.

Database improvements:

* [`lib/data/database/database.dart`](diffhunk://#diff-3aa1db4bc0ce0feecce54295d853a81ce112624cb44707616c82b619ace7d3d3R3): Added an import for `path` to handle file paths more effectively.
* [`lib/data/database/database.dart`](diffhunk://#diff-3aa1db4bc0ce0feecce54295d853a81ce112624cb44707616c82b619ace7d3d3R108-R112): Modified the `DatabaseService` class to ensure only the file name is saved in the `imageUrl` field by using `path.basename`.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L19-R19): Updated the project version from `1.1.0+2` to `1.1.0+3`.